### PR TITLE
Add copy bit at the end of the output only when required

### DIFF
--- a/cruncher.c
+++ b/cruncher.c
@@ -640,7 +640,9 @@ int writeOutput() {
 
   }
 
-  wBit(1);
+  if(needCopyBit) {
+    wBit(1);
+  }
   wLength(0xff);
   wFlush();
 


### PR DESCRIPTION
The issue about the presence of an extra copy bit at the end of a compressed file is pretty much unharmful unless crunched files are linked together. The issue becomes evident when the last data bit of the 0xFF value overflows into an extra byte (0x80) due to a previously written copy bit that should not be there: the decruncher will therefore not fetch the extra byte to extract the single data bit that’s stored in it because it will have already read the spurious copy bit instead.